### PR TITLE
Update to v22.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+channels:
+  melody_org: flask-update
+build_parameters:
+  - "--suppress-variables"
+  - "--error-overlinking"
+  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  melody_org: flask-update
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
 build:
   number: 0
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
+  skip: true  # [py<37]
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "cattrs" %}
-{% set version = "1.7.1" %}
-{% set sha256 = "95265b8aaa45e6de75b5f52ae081e021a2a7a688babdb711e4174e6b18920d08" %}
+{% set version = "22.1.0" %}
+{% set sha256 = "94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6" %}
 
 package:
   name: {{ name|lower }}
@@ -13,20 +13,20 @@ source:
 
 build:
   number: 0
-  noarch: python
   script: '{{ PYTHON }} -m pip install . --no-deps --ignore-installed -vv '
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
     - attrs >=20.1.0
     - poetry-core >=1.0.0
     - wheel
-    - setuptools
   run:
-    - python >=3.7
+    - python
     - attrs >=20.1.0
+    - exceptiongroup  # [py<311]
+    - typing_extensions  # [py<38]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,6 @@ requirements:
   host:
     - python
     - pip
-    - attrs >=20.1.0
     - poetry-core >=1.0.0
     - wheel
   run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -50,7 +50,7 @@ test:
   #   - tests
 
 about:
-  home: https://github.com/Tinche/cattrs
+  home: https://github.com/python-attrs/cattrs
   license: MIT
   license_family: MIT
   license_file: LICENSE
@@ -60,7 +60,7 @@ about:
     cattrs works best with attrs classes and the usual Python collections, but other
     kinds of classes are supported by manually registering converters.
   doc_url: https://cattrs.readthedocs.io/en/latest/
-  dev_url: https://github.com/Tinche/cattrs
+  dev_url: https://github.com/python-attrs/cattrs
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Update `cattrs` to v22.1.0

[airflow 2.4.3](https://github.com/AnacondaRecipes/airflow-feedstock/pull/13) --> `cattrs 22.1.0`

Jira ticket: [PKG-574](https://anaconda.atlassian.net/browse/PKG-574)

Home: https://github.com/Tinche/cattrs
Development: https://github.com/Tinche/cattrs
Documentation: https://cattrs.readthedocs.io/en/latest/
Change log: https://github.com/python-attrs/cattrs/blob/main/HISTORY.rst#2210-2022-04-03