### PR TITLE
cattrs 26.1.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "cattrs" %}
-{% set version = "25.3.0" %}
+{% set version = "26.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,12 +7,12 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1ac88d9e5eda10436c4517e390a4142d88638fe682c436c93db7ce4a277b884a
+  sha256: fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<39]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:


### PR DESCRIPTION
cattrs 26.1.0 

**Destination channel:** Defaults

### Links

- [PKG-12579]
- dev_url:        https://github.com/python-attrs/cattrs/tree/v26.1.0
- conda_forge:    https://github.com/conda-forge/cattrs-feedstock
- pypi:           https://pypi.org/project/cattrs/26.1.0
- pypi inspector: https://inspector.pypi.io/project/cattrs/26.1.0

### Explanation of changes:

- new version number


[PKG-12579]: https://anaconda.atlassian.net/browse/PKG-12579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ